### PR TITLE
Added folder argument to gdrive_dir

### DIFF
--- a/R/gdrive_dir.R
+++ b/R/gdrive_dir.R
@@ -2,9 +2,11 @@
 #'
 #' Prints the structure of the Shared Google Drive to the console. It provides a count of the files within
 #' each folder and all subfolders. Items in the 'path' column can be copy-pasted to use as the
-#' `gdrive_path` argument of the `gdrive_set_dribble(gdrive_path)` function.
+#' `gdrive_path` argument of the `gdrive_set_dribble(gdrive_path)` function. Highly recommended to use the `folder`
+#' argument as it will speed up your search.
 #'
 #' @param shared_id An alias of a Shared Google Drive. By default, the drive for FMA Analytics.
+#' @param folder A character file path of folders, i.e., "Projects", that will narrow down your search.
 #'
 #' @details
 #' Use this function to retrieve the file paths of every folder in the Shared Google Drive.
@@ -21,7 +23,7 @@
 #' }
 #'
 #' @export
-gdrive_dir <- function(shared_id = c("Analytics")) {
+gdrive_dir <- function(shared_id = c("Analytics"), folder = NULL) {
 
   if( !is.character(shared_id) | length(shared_id) != 1) stop("'id' needs to be a length = 1 character string.")
 
@@ -30,34 +32,49 @@ gdrive_dir <- function(shared_id = c("Analytics")) {
     id <- "0AJcHJWlPgKIgUk9PVA"
   } else stop("")
 
-  # Get the dribble of the shared drive
-  gdrive_dribble <- googledrive::shared_drive_get(id = id)
+  gdrive_head <- googledrive::with_drive_quiet(googledrive::shared_drive_get(id = id))
+  # If 'folder' is specified, only dig through file structure of that folder.
+  if( !is.null(folder) ){
+
+    # Remove any trailing slashes
+    folder <- sub("[.]*/$", "", folder)
+    gdrive_dribble <- googledrive::with_drive_quiet(googledrive::drive_get(path = folder, shared_drive = gdrive_head))
+  } else {
+    # Get the dribble of the shared drive
+    gdrive_dribble <- gdrive_head
+  }
+
   parent <- gdrive_dribble
   parent_search <- dir_search(parent)
 
-  #while( !is.null(parent_search$child) ) {
-  while( nrow(parent_search$child) > 0 ) {
+  while( nrow(parent_search$child) > 0 ){
     new_parent <- parent_search$child
     new_parent_search <- dir_search(new_parent)
     parent_search <- list(
-      parent = rbind(parent_search$parent, new_parent_search$parent),
+      parent = rbind(parent_search$parent[, c("name", "id", "drive_resource", "files")], new_parent_search$parent),
       child = new_parent_search$child,
       fill = T
     )
   }
 
   # Omit the shared folder from the output
-  folders_df <- parent_search$parent[-1, ]
+  if( is.null(folder) ){
+    folders_df <- parent_search$parent[-1, ]
+  } else {
+    folders_df <- parent_search$parent
+  }
+
   # Omit the shared folder from name, and add a "/" to the path names to specify these are folders and not files
   folders_df$gdrive_path <- sub(paste0(gdrive_dribble$name, "/"), "", paste0(folders_df$name, "/"))
 
   # Print the results
-  cat("Shared Drive:", gdrive_dribble$name, "\n")
+  cat("Shared Drive:", paste0(gdrive_head$name, "/", folder), "\n")
 
   # Format the output
   out <- folders_df[, c("gdrive_path", "files")]
+  if( !is.null(folder) ) out$gdrive_path <- paste0(folder, "/", out$gdrive_path)
   out <- out[order(out$gdrive_path), ]
-  out$abbr_name <- gsub("([^/]+)(?=/.+)", "..", out$gdrive_path, perl = T)  # close, just a bit too much
+  out$abbr_name <- gsub("([^/]+)(?=/.+)", "..", out$gdrive_path, perl = T)
   out$nchar <- nchar(out$abbr_name)
   out$ws <- max(out$nchar) - out$nchar
   out$Directory <- apply(out, 1, function(x) paste0(x["abbr_name"], paste(rep(" ", times = x["ws"]), collapse = "")))

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -316,7 +316,7 @@ dir_search <- function(dribble) {
     if( nrow(drive_items) == 0 ) {
       dribble_lst[[i]] <- list(
         parent = parent[i,],
-        child = NULL
+        child = parent[0, c("name", "id", "drive_resource")]
       )
     } else {
 

--- a/man/gdrive_dir.Rd
+++ b/man/gdrive_dir.Rd
@@ -4,10 +4,12 @@
 \alias{gdrive_dir}
 \title{Show the Folder Structure of the Shared Google Drive}
 \usage{
-gdrive_dir(shared_id = c("Analytics"))
+gdrive_dir(shared_id = c("Analytics"), folder = NULL)
 }
 \arguments{
 \item{shared_id}{An alias of a Shared Google Drive. By default, the drive for FMA Analytics.}
+
+\item{folder}{A character file path of folders, i.e., "Projects", that will narrow down your search.}
 }
 \value{
 Returns a data frame of the folder structure of the Shared Google Drive.
@@ -15,7 +17,8 @@ Returns a data frame of the folder structure of the Shared Google Drive.
 \description{
 Prints the structure of the Shared Google Drive to the console. It provides a count of the files within
 each folder and all subfolders. Items in the 'path' column can be copy-pasted to use as the
-\code{gdrive_path} argument of the \code{gdrive_set_dribble(gdrive_path)} function.
+\code{gdrive_path} argument of the \code{gdrive_set_dribble(gdrive_path)} function. Highly recommended to use the \code{folder}
+argument as it will speed up your search.
 }
 \details{
 Use this function to retrieve the file paths of every folder in the Shared Google Drive.


### PR DESCRIPTION
This argument speeds up the folder search for the shared drive. Not sure of a method to speed the search up, because a separate request to the API has to be made for each folder. However, narrowing down the search drastically speeds things up.