### PR TITLE
Dev geoff

### DIFF
--- a/gdrive_quick_reference.md
+++ b/gdrive_quick_reference.md
@@ -1,9 +1,3 @@
----
-editor_options: 
-  markdown: 
-    wrap: 72
----
-
 # Shared Google Drive - Quick Reference
 
 These functions can be used to streamline our workflow by using our

--- a/gdrive_quick_reference.md
+++ b/gdrive_quick_reference.md
@@ -126,7 +126,7 @@ does not print the name of enclosed folders.
 
 ------------------------------------------------------------------------
 
-### **gdrive_ver()**
+### **gdrive_versions()** {#gdrive_versions}
 
 **Syntax:** `gdrive_versions(gdrive_file, gdrive_dribble)`
 


### PR DESCRIPTION
Fixing hyperlinks of quick reference markdown.

Making the .md in R was a bad idea. The 'preview' adds junk to the script and relies on a different hyperlink syntax than what github uses. Easier to just develop a .md file in the GitHub IDE.