### PR TITLE
Bug fix for gdrive tools and commenting out problematic function

### DIFF
--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -503,32 +503,36 @@ compare_local_and_gdrive <- function(l_path, g_path){
     if( all(gdrive_raw$content == local_raw) ) {
       identical <- T
       local_status <- "up to date with"
+    } else {
+      identical <- F
+      local_status <- ifelse(mtime_match > 0, "behind", "ahead of")
     }
   } else {
     # *If the files aren't identical, declare whether the local or the gdrive is ahead*
     identical <- F
     local_status <- ifelse(mtime_match > 0, "behind", "ahead of")
     gdrive_raw <- NULL
-
-    if( local_status == "behind" ){
-      # *If the local is behind, check to see if the local_mtime matches any prior gdrive versions*
-      local_match_ver <- (sapply(g_path$revision_lst, "[[", "modifiedTime") == trunc(local_info$mtime))
-      # If there is a match, print the version
-      if( any(local_match_ver) ){
-        cat(paste0(
-          "Local copy of ", crayon::bold(l_path$name), " appears to be on ",
-          crayon::yellow(paste0("[ver", which(local_match_ver), "]")),
-          " whereas the Gdrive is on ", crayon::yellow(paste0("[ver", g_path$current_ver, "]")), ".\n"
-        ))
-      }
-    }
-
-    # Print the modified dates of the local and gdrive versions
-    cat(paste0(
-      "Modified datetimes of ", crayon::bold(l_path$name), ":\n- Local:  ", round(local_info$mtime),
-      "\n- Gdrive: ", gdrive_head$modifiedTime, "\n"
-    ))
   }
+
+  if( local_status == "behind" ){
+    # *If the local is behind, check to see if the local_mtime matches any prior gdrive versions*
+    local_match_ver <- (sapply(g_path$revision_lst, "[[", "modifiedTime") == trunc(local_info$mtime))
+    # If there is a match, print the version
+    if( any(local_match_ver) ){
+      cat(paste0(
+        "Local copy of ", crayon::bold(l_path$name), " appears to be on ",
+        crayon::yellow(paste0("[ver", which(local_match_ver), "]")),
+        " whereas the Gdrive is on ", crayon::yellow(paste0("[ver", g_path$current_ver, "]")), ".\n"
+      ))
+    }
+  }
+
+  # Print the modified dates of the local and gdrive versions
+  cat(paste0(
+    "Modified datetimes of ", crayon::bold(l_path$name), ":\n- Local:  ", round(local_info$mtime),
+    "\n- Gdrive: ", gdrive_head$modifiedTime, "\n"
+  ))
+
 
   # Outputs
   list(

--- a/R/keyring_setup.R
+++ b/R/keyring_setup.R
@@ -1,34 +1,36 @@
-# For those using R to directly access AFSC and AKFIN might I recommend the
-# 'keyring' package for logging in without providing info on public domains
-# (e.g., github)
+#' *GEOFF MAYHEW COMMENTED THIS OUT BECAUSE THIS FUNCTION WAS NOT PROPERLY LOADED AND IT BROKE THE dev_tools::check()*
 
-# using keyring
-# install.packages('keyring')
-library(keyring)
-
-# store password and user name for a database at a high level (aka not publicly accessible)
-keyring::key_set_with_value(service="afsc", username="SULLIVANJ", password = "Zbfabfj$12!#$856")
-keyring::key_set_with_value(service="akfin", username="jsullivan", password = "sculja22")
-
-# the username and password can then be called with 
-db <- "afsc"
-keyring::key_list(db)$username
-keyring::key_get(db, keyring::key_list(db)$username)
-
-# this can be password on to a server connection:
-DBI::dbConnect(odbc::odbc(),
-               dsn = db,
-               uid = keyring::key_list(db)$username,
-               pwd =  keyring::key_get(db, keyring::key_list(db)$username))
-
-db <- "akfin"
-keyring::key_list(db)$username
-keyring::key_get(db, keyring::key_list(db)$username)
-
-DBI::dbConnect(odbc::odbc(),
-               db,
-               uid = keyring::key_list(db)$username,
-               pwd =  keyring::key_get(db, keyring::key_list(db)$username))
-
-# when your afsc pwd is updated you can easily change it using 
-keyring::key_set_with_value(service=db, username="KINGHAMA", password = "MyPassword")
+# # For those using R to directly access AFSC and AKFIN might I recommend the
+# # 'keyring' package for logging in without providing info on public domains
+# # (e.g., github)
+#
+# # using keyring
+# # install.packages('keyring')
+# library(keyring)
+#
+# # store password and user name for a database at a high level (aka not publicly accessible)
+# keyring::key_set_with_value(service="afsc", username="SULLIVANJ", password = "Zbfabfj$12!#$856")
+# keyring::key_set_with_value(service="akfin", username="jsullivan", password = "sculja22")
+#
+# # the username and password can then be called with
+# db <- "afsc"
+# keyring::key_list(db)$username
+# keyring::key_get(db, keyring::key_list(db)$username)
+#
+# # this can be password on to a server connection:
+# DBI::dbConnect(odbc::odbc(),
+#                dsn = db,
+#                uid = keyring::key_list(db)$username,
+#                pwd =  keyring::key_get(db, keyring::key_list(db)$username))
+#
+# db <- "akfin"
+# keyring::key_list(db)$username
+# keyring::key_get(db, keyring::key_list(db)$username)
+#
+# DBI::dbConnect(odbc::odbc(),
+#                db,
+#                uid = keyring::key_list(db)$username,
+#                pwd =  keyring::key_get(db, keyring::key_list(db)$username))
+#
+# # when your afsc pwd is updated you can easily change it using
+# keyring::key_set_with_value(service=db, username="KINGHAMA", password = "MyPassword")


### PR DESCRIPTION
The `gdrive` functions had a bug where the comparison of the local file and the gdrive file would get tripped up if they were the same file size.

I also had to comment out Andy's `keyring_setup.R` script because it was causing the devtools::check() to fail, as it was not properly document with the dependencies (keyring package). We can re-activate it in a future PR.