### PR TITLE
when ver is supplied, format to integer

### DIFF
--- a/R/gdrive_download.R
+++ b/R/gdrive_download.R
@@ -92,6 +92,8 @@ gdrive_download <- function(local_path, gdrive_dribble, ver = NULL) {
   } else {
     # *Downloading a prior version*
 
+    # First, convert numeric ver to integer class
+    ver <- as.integer(ver)
     # check to see if the file already exists
     ver_path <- paste0(
       l_path$directory, l_path$name_no_ext, "_v", formatC(ver, width = 3, digits = 0, flag = "0" ), l_path$extension


### PR DESCRIPTION
Ran into a bug where if you specify a `ver` to `gdrive_download()` that is > 9, the version of the file that is downloaded prints the file version in scientific (numeric) notation rather than as an integer, i.e., `v1e+01` instead of `v001`. For forcing `ver` to be an integer when it is supplied (otherwise NULL), this should fix the problem.