### PR TITLE
Added ellipses to gdrive_versions

### DIFF
--- a/R/gdrive_versions.R
+++ b/R/gdrive_versions.R
@@ -2,6 +2,7 @@
 #'
 #' @param local_path the name of the .rdata or .rds file on the Gdrive
 #' @param gdrive_dribble the `dribble` class object of the folder where your requested file resides.
+#' @param ... not used, but allows you to easily replace calls to gdrive_versions without removing additional args
 #'
 #' @return Returns a data.frame showing the file's revision history, including modification dates and users and file size
 #' @export
@@ -11,7 +12,7 @@
 #'    "geoff_mayhew_tutorial.rdata",
 #'    gdrive_set_dribble("Google Drive Test/")
 #' )
-gdrive_versions <- function(local_path, gdrive_dribble){
+gdrive_versions <- function(local_path, gdrive_dribble, ...){
 
   # Ensure googledrive token is active
   gdrive_token()

--- a/man/gdrive_versions.Rd
+++ b/man/gdrive_versions.Rd
@@ -4,12 +4,14 @@
 \alias{gdrive_versions}
 \title{View the Revision History of a Data File on the Gdrive}
 \usage{
-gdrive_versions(local_path, gdrive_dribble)
+gdrive_versions(local_path, gdrive_dribble, ...)
 }
 \arguments{
 \item{local_path}{the name of the .rdata or .rds file on the Gdrive}
 
 \item{gdrive_dribble}{the \code{dribble} class object of the folder where your requested file resides.}
+
+\item{...}{not used, but allows you to easily replace calls to gdrive_versions without removing additional args}
 }
 \value{
 Returns a data.frame showing the file's revision history, including modification dates and users and file size

--- a/scripts/function_test_script.R
+++ b/scripts/function_test_script.R
@@ -62,5 +62,9 @@ gdrive_download(local_dat_filepath, test_data_dribble)
 #======================================================================================================================#
 
 ### Check file versions ----
-
+local_dat_filepath <- "test_data/dummy_dat.Rdata"
 gdrive_versions(local_dat_filepath, test_data_dribble)
+# Should also work if you have other arguments, like if you're just changing a call to gdrive_download()
+gdrive_versions(local_dat_filepath, test_data_dribble, ver = 3, temp = T)
+
+


### PR DESCRIPTION
Allows you to easily swap out `gdrive_download` with `gdrive_versions`, even if there are additional arguments like `temp` and `ver` in the original call. 